### PR TITLE
Explicitly run migrations as they are not part of the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apk add crystal                       \
     shards build silvio-server         && \
     mv bin/silvio-server /bin          && \
                                           \
+    bin/micrate up                     && \
+                                          \
     apk del crystal                       \
             shards                        \
             libressl-dev                  \

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Silvio is a VPN-over-WebSocket implementation, based on the TUN interface. I am 
 
 ## Installation
 
-The code is written in Crystal and uses SQLite to store the information about the networks and clients, these are the two main requirements. You can build both the server and the client with the following command:
+The code is written in Crystal and uses SQLite to store the information about the networks and clients, these are the two main requirements. You can build the server and client and run the necessary DB migrations using following commands:
 ```sh
 shards build
+DATABASE_PATH=/path/to/your/db/file bin/micrate up
 ```
 
 ## Usage

--- a/bin/micrate
+++ b/bin/micrate
@@ -1,0 +1,10 @@
+#! /usr/bin/env crystal
+
+require "sqlite3"
+require "micrate"
+
+ENV["CRYSTAL_ENV"] ||= "development"
+ENV["DATABASE_PATH"] ||= "db/#{ENV["CRYSTAL_ENV"]}.sqlite3"
+Micrate::DB.connection_url = "sqlite3://#{ENV["DATABASE_PATH"]}"
+
+Micrate::Cli.run

--- a/spec/ping/test-server.sh
+++ b/spec/ping/test-server.sh
@@ -8,6 +8,7 @@ set -x
 
 # Create static binaries and run the server
 shards build --static
+bin/micrate up
 bin/silvio-server &
 
 sleep 5

--- a/src/silvio-server.cr
+++ b/src/silvio-server.cr
@@ -19,7 +19,7 @@ OptionParser.parse! do |p|
   end
 end
 
-ENV["DATABASE_PATH"] = config[:path].to_s
+ENV["DATABASE_PATH"] ||= config[:path].to_s
 
 require "./silvio"
 require "./silvio/api"

--- a/src/silvio/database.cr
+++ b/src/silvio/database.cr
@@ -1,5 +1,4 @@
 require "sqlite3"
-require "micrate"
 require "crecto"
 
 module Silvio::Database
@@ -8,9 +7,6 @@ module Silvio::Database
   config do |conf|
     conf.adapter = Crecto::Adapters::SQLite3
     conf.uri = "sqlite3://#{ENV["DATABASE_PATH"]}"
-    # Run the migrations before accessing the database
-    Micrate::DB.connection_url = conf.uri
-    Micrate::Cli.run_up
   end
 
   class Network < Crecto::Model


### PR DESCRIPTION
Fixes migration issues with the server's docker container.